### PR TITLE
feat(settings): 支持可配置 API 与 OpenAI 兼容模式

### DIFF
--- a/src/electron/ipc-handlers.ts
+++ b/src/electron/ipc-handlers.ts
@@ -84,10 +84,11 @@ export function handleClientEvent(event: ClientEvent) {
       payload: { sessionId: session.id, prompt: event.payload.prompt }
     });
 
+    // 新会话不传递 resumeSessionId，确保不加载历史记录
     runClaude({
       prompt: event.payload.prompt,
       session,
-      resumeSessionId: session.claudeSessionId,
+      resumeSessionId: undefined,
       onEvent: emit,
       onSessionUpdate: (updates) => {
         sessions.updateSession(session.id, updates);

--- a/src/electron/libs/claude-settings.ts
+++ b/src/electron/libs/claude-settings.ts
@@ -2,6 +2,7 @@ import type { ClaudeSettingsEnv } from "../types.js";
 import { readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
+import { loadApiConfig, type ApiConfig } from "./config-store.js";
 
 const CLAUDE_SETTINGS_ENV_KEYS = [
   "ANTHROPIC_AUTH_TOKEN",
@@ -15,6 +16,10 @@ const CLAUDE_SETTINGS_ENV_KEYS = [
 ] as const;
 
 export function loadClaudeSettingsEnv(): ClaudeSettingsEnv {
+  // 优先使用界面配置
+  const uiConfig = loadApiConfig();
+  
+  // 加载 ~/.claude/settings.json 作为后备
   try {
     const settingsPath = join(homedir(), ".claude", "settings.json");
     const raw = readFileSync(settingsPath, "utf8");
@@ -34,7 +39,75 @@ export function loadClaudeSettingsEnv(): ClaudeSettingsEnv {
   for (const key of CLAUDE_SETTINGS_ENV_KEYS) {
     env[key] = process.env[key] ?? "";
   }
+
+  // 如果存在界面配置，覆盖相应字段
+  if (uiConfig) {
+    env.ANTHROPIC_AUTH_TOKEN = uiConfig.apiKey;
+    env.ANTHROPIC_BASE_URL = uiConfig.baseURL;
+    env.ANTHROPIC_MODEL = uiConfig.model;
+  }
+
   return env;
+}
+
+// 获取当前有效的配置（优先界面配置，回退到文件配置）
+export function getCurrentApiConfig(): ApiConfig | null {
+  const uiConfig = loadApiConfig();
+  if (uiConfig) {
+    console.log("[claude-settings] Using UI config:", { 
+      baseURL: uiConfig.baseURL, 
+      model: uiConfig.model, 
+      apiType: uiConfig.apiType 
+    });
+    return uiConfig;
+  }
+
+  // 回退到 ~/.claude/settings.json
+  try {
+    const settingsPath = join(homedir(), ".claude", "settings.json");
+    const raw = readFileSync(settingsPath, "utf8");
+    const parsed = JSON.parse(raw) as { env?: Record<string, unknown> };
+    if (parsed.env) {
+      const authToken = parsed.env.ANTHROPIC_AUTH_TOKEN;
+      const baseURL = parsed.env.ANTHROPIC_BASE_URL;
+      const model = parsed.env.ANTHROPIC_MODEL;
+      
+      if (authToken && baseURL && model) {
+        console.log("[claude-settings] Using file config from ~/.claude/settings.json");
+        return {
+          apiKey: String(authToken),
+          baseURL: String(baseURL),
+          model: String(model),
+          apiType: "anthropic" // 从文件读取的配置默认为 anthropic
+        };
+      }
+    }
+  } catch {
+    // Ignore missing or invalid settings file.
+  }
+
+  console.log("[claude-settings] No config found");
+  return null;
+}
+
+// 构建环境变量对象，用于传递给 SDK（仅用于 Anthropic API）
+export function buildEnvForConfig(config: ApiConfig | null): Record<string, string> {
+  const baseEnv = { ...process.env } as Record<string, string>;
+  
+  // 只对 Anthropic API 类型设置环境变量
+  if (config && config.apiType !== "openai-compatible") {
+    baseEnv.ANTHROPIC_AUTH_TOKEN = config.apiKey;
+    baseEnv.ANTHROPIC_BASE_URL = config.baseURL;
+    baseEnv.ANTHROPIC_MODEL = config.model;
+  } else if (!config) {
+    // 使用默认配置（从 ~/.claude/settings.json）
+    const defaultEnv = loadClaudeSettingsEnv();
+    baseEnv.ANTHROPIC_AUTH_TOKEN = defaultEnv.ANTHROPIC_AUTH_TOKEN;
+    baseEnv.ANTHROPIC_BASE_URL = defaultEnv.ANTHROPIC_BASE_URL;
+    baseEnv.ANTHROPIC_MODEL = defaultEnv.ANTHROPIC_MODEL;
+  }
+  
+  return baseEnv;
 }
 
 export const claudeCodeEnv = loadClaudeSettingsEnv();

--- a/src/electron/libs/config-store.ts
+++ b/src/electron/libs/config-store.ts
@@ -1,0 +1,84 @@
+import { app } from "electron";
+import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from "fs";
+import { join } from "path";
+
+export type ApiType = "anthropic" | "openai-compatible";
+
+export type ApiConfig = {
+  apiKey: string;
+  baseURL: string;
+  model: string;
+  apiType?: ApiType; // 默认为 "anthropic" 以保持向后兼容
+};
+
+const CONFIG_FILE_NAME = "api-config.json";
+
+function getConfigPath(): string {
+  const userDataPath = app.getPath("userData");
+  return join(userDataPath, CONFIG_FILE_NAME);
+}
+
+export function loadApiConfig(): ApiConfig | null {
+  try {
+    const configPath = getConfigPath();
+    if (!existsSync(configPath)) {
+      return null;
+    }
+    const raw = readFileSync(configPath, "utf8");
+    const config = JSON.parse(raw) as ApiConfig;
+    // 验证配置格式
+    if (config.apiKey && config.baseURL && config.model) {
+      // 设置默认 apiType
+      if (!config.apiType) {
+        config.apiType = "anthropic";
+      }
+      return config;
+    }
+    return null;
+  } catch (error) {
+    console.error("[config-store] Failed to load API config:", error);
+    return null;
+  }
+}
+
+export function saveApiConfig(config: ApiConfig): void {
+  try {
+    const configPath = getConfigPath();
+    const userDataPath = app.getPath("userData");
+    
+    // 确保目录存在
+    if (!existsSync(userDataPath)) {
+      mkdirSync(userDataPath, { recursive: true });
+    }
+    
+    // 验证配置
+    if (!config.apiKey || !config.baseURL || !config.model) {
+      throw new Error("Invalid config: apiKey, baseURL, and model are required");
+    }
+    
+    // 设置默认 apiType
+    if (!config.apiType) {
+      config.apiType = "anthropic";
+    }
+    
+    // 保存配置
+    writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8");
+    console.info("[config-store] API config saved successfully");
+  } catch (error) {
+    console.error("[config-store] Failed to save API config:", error);
+    throw error;
+  }
+}
+
+export function deleteApiConfig(): void {
+  try {
+    const configPath = getConfigPath();
+    if (existsSync(configPath)) {
+      unlinkSync(configPath);
+      console.info("[config-store] API config deleted");
+    }
+  } catch (error) {
+    console.error("[config-store] Failed to delete API config:", error);
+  }
+}
+

--- a/src/electron/libs/openai-adapter.ts
+++ b/src/electron/libs/openai-adapter.ts
@@ -1,0 +1,575 @@
+import type { SDKMessage, PermissionResult } from "@anthropic-ai/claude-agent-sdk";
+import type { ApiConfig } from "./config-store.js";
+
+// OpenAI API 类型定义
+type OpenAIMessage = {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string | Array<{ type: string; text?: string; image_url?: { url: string } }>;
+  tool_calls?: Array<{
+    id: string;
+    type: "function";
+    function: {
+      name: string;
+      arguments: string;
+    };
+  }>;
+  tool_call_id?: string;
+};
+
+type OpenAIRequest = {
+  model: string;
+  messages: OpenAIMessage[];
+  stream: boolean;
+  tools?: Array<{
+    type: "function";
+    function: {
+      name: string;
+      description: string;
+      parameters: Record<string, unknown>;
+    };
+  }>;
+  tool_choice?: "auto" | "none" | { type: "function"; function: { name: string } };
+};
+
+type OpenAIStreamChunk = {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    delta: {
+      role?: string;
+      content?: string;
+      tool_calls?: Array<{
+        index: number;
+        id?: string;
+        type?: "function";
+        function?: {
+          name?: string;
+          arguments?: string;
+        };
+      }>;
+    };
+    finish_reason?: string | null;
+  }>;
+};
+
+type OpenAIToolDefinition = {
+  type: "function";
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  };
+};
+
+// 工具定义映射（从 Anthropic 工具格式转换为 OpenAI 格式）
+const ANTHROPIC_TOOLS: Record<string, OpenAIToolDefinition> = {
+  ReadFile: {
+    type: "function",
+    function: {
+      name: "ReadFile",
+      description: "Read the contents of a file",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "The path to the file to read" }
+        },
+        required: ["path"]
+      }
+    }
+  },
+  WriteFile: {
+    type: "function",
+    function: {
+      name: "WriteFile",
+      description: "Write content to a file",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "The path to the file to write" },
+          content: { type: "string", description: "The content to write" }
+        },
+        required: ["path", "content"]
+      }
+    }
+  },
+  ListDirectory: {
+    type: "function",
+    function: {
+      name: "ListDirectory",
+      description: "List the contents of a directory",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "The path to the directory to list" }
+        },
+        required: ["path"]
+      }
+    }
+  },
+  RunCommand: {
+    type: "function",
+    function: {
+      name: "RunCommand",
+      description: "Run a shell command",
+      parameters: {
+        type: "object",
+        properties: {
+          command: { type: "string", description: "The command to run" }
+        },
+        required: ["command"]
+      }
+    }
+  },
+  AskUserQuestion: {
+    type: "function",
+    function: {
+      name: "AskUserQuestion",
+      description: "Ask the user a question",
+      parameters: {
+        type: "object",
+        properties: {
+          question: { type: "string", description: "The question to ask the user" }
+        },
+        required: ["question"]
+      }
+    }
+  }
+};
+
+// 将消息历史转换为 OpenAI 格式
+function convertMessagesToOpenAI(messages: OpenAIMessage[]): OpenAIMessage[] {
+  return messages.map(msg => {
+    if (typeof msg.content === "string") {
+      return msg;
+    }
+    // 处理多模态内容
+    return {
+      ...msg,
+      content: msg.content.map(item => {
+        if (item.type === "text") {
+          return { type: "text", text: item.text || "" };
+        }
+        return item;
+      })
+    };
+  });
+}
+
+
+// 调用 OpenAI 兼容的聊天完成 API
+export async function* openaiChatCompletion(
+  config: ApiConfig,
+  prompt: string,
+  messageHistory: OpenAIMessage[] = [],
+  onToolCall?: (toolName: string, input: unknown, toolCallId: string) => Promise<PermissionResult>,
+  abortSignal?: AbortSignal,
+  options?: {
+    cwd?: string;
+    permissionMode?: string;
+  }
+): AsyncGenerator<SDKMessage, void, unknown> {
+  const baseURL = config.baseURL.endsWith("/")
+      ? config.baseURL.slice(0, -1)
+      : config.baseURL;
+  const apiURL = baseURL.includes("/v1")
+      ? `${baseURL}/chat/completions`
+      : `${baseURL}/v1/chat/completions`;
+
+  const sessionId = crypto.randomUUID();
+  let currentMessageHistory: OpenAIMessage[] = [...messageHistory];
+
+  // 如果是第一次调用，添加用户消息
+  if (prompt) {
+    currentMessageHistory.push({role: "user", content: prompt});
+  }
+
+  // 循环处理多轮对话（包括工具调用）
+  while (true) {
+    // 构建请求
+    const requestBody: OpenAIRequest = {
+      model: config.model,
+      messages: convertMessagesToOpenAI(currentMessageHistory),
+      stream: true,
+      tools: Object.values(ANTHROPIC_TOOLS),
+      tool_choice: "auto"
+    };
+
+    let accumulatedContent = "";
+    let accumulatedToolCalls: Array<{ id: string; name: string; arguments: string }> = [];
+    let hasToolCalls = false;
+
+    try {
+      console.log("[openai-adapter] Making request to:", apiURL);
+      console.log("[openai-adapter] Request body:", JSON.stringify(requestBody, null, 2));
+
+      const response = await fetch(apiURL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${config.apiKey}`
+        },
+        body: JSON.stringify(requestBody),
+        signal: abortSignal
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error("[openai-adapter] API request failed:", response.status, errorText);
+        throw new Error(`OpenAI API error: ${response.status} ${errorText}`);
+      }
+
+      if (!response.body) {
+        console.error("[openai-adapter] No response body");
+        throw new Error("No response body");
+      }
+
+      console.log("[openai-adapter] Response received, status:", response.status);
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let hasReceivedData = false;
+
+      // 只在第一次请求时发送初始化消息
+      if (currentMessageHistory.length === (messageHistory.length + (prompt ? 1 : 0))) {
+        yield {
+          type: "system",
+          subtype: "init",
+          uuid: crypto.randomUUID(),
+          session_id: sessionId,
+          model: config.model,
+          permissionMode: options?.permissionMode || "bypassPermissions",
+          cwd: options?.cwd || "-"
+        } as unknown as SDKMessage;
+      }
+
+      while (true) {
+        const {done, value} = await reader.read();
+        if (done) {
+          console.log("[openai-adapter] Stream ended, buffer:", buffer);
+          break;
+        }
+
+        hasReceivedData = true;
+        buffer += decoder.decode(value, {stream: true});
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          if (line.trim() === "" || !line.startsWith("data: ")) {
+            if (line.trim() !== "") {
+              console.log("[openai-adapter] Skipping non-data line:", line);
+            }
+            continue;
+          }
+
+          const dataStr = line.slice(6);
+          if (dataStr === "[DONE]") {
+            console.log("[openai-adapter] Received [DONE] marker");
+            // 流结束，跳出内层循环
+            break;
+          }
+
+          try {
+            const chunk: OpenAIStreamChunk = JSON.parse(dataStr);
+            console.log("[openai-adapter] Parsed chunk:", JSON.stringify(chunk).substring(0, 200));
+
+            // 处理内容增量
+            if (chunk.choices[0]?.delta?.content) {
+              accumulatedContent += chunk.choices[0].delta.content;
+              // 直接生成流式消息
+              yield {
+                type: "stream_event",
+                event: {
+                  type: "content_block_delta",
+                  delta: {
+                    type: "text",
+                    text: chunk.choices[0].delta.content
+                  }
+                },
+                parent_tool_use_id: null,
+                uuid: crypto.randomUUID(),
+                session_id: sessionId
+              } as unknown as SDKMessage;
+            }
+
+            // 处理工具调用增量
+            if (chunk.choices[0]?.delta?.tool_calls) {
+              for (const toolCall of chunk.choices[0].delta.tool_calls) {
+                if (toolCall.id && toolCall.function) {
+                  const existingIndex = accumulatedToolCalls.findIndex(tc => tc.id === toolCall.id);
+                  if (existingIndex >= 0) {
+                    // 累积参数
+                    accumulatedToolCalls[existingIndex].arguments += toolCall.function.arguments || "";
+                    // 更新名称（如果提供了）
+                    if (toolCall.function.name) {
+                      accumulatedToolCalls[existingIndex].name = toolCall.function.name;
+                    }
+                  } else {
+                    // 新的工具调用
+                    accumulatedToolCalls.push({
+                      id: toolCall.id,
+                      name: toolCall.function.name || "",
+                      arguments: toolCall.function.arguments || ""
+                    });
+                  }
+                }
+              }
+            }
+
+            // 处理完成状态
+            const finishReason = chunk.choices[0]?.finish_reason;
+            console.log("[openai-adapter] Finish reason:", finishReason, "accumulatedContent length:", accumulatedContent.length, "toolCalls:", accumulatedToolCalls.length);
+            
+            if (finishReason === "stop") {
+              // 文本完成，发送最终消息
+              if (accumulatedContent) {
+                yield {
+                  type: "assistant",
+                  message: {
+                    content: [{type: "text", text: accumulatedContent}],
+                    role: "assistant"
+                  },
+                  parent_tool_use_id: null,
+                  uuid: crypto.randomUUID(),
+                  session_id: sessionId
+                } as unknown as SDKMessage;
+                // 更新消息历史
+                currentMessageHistory.push({
+                  role: "assistant",
+                  content: accumulatedContent
+                });
+              }
+              // 跳出内层循环，准备发送最终结果
+              break;
+            } else if (finishReason === "tool_calls" && accumulatedToolCalls.length > 0) {
+              // 工具调用完成
+              hasToolCalls = true;
+              
+              // 确保所有工具调用的参数都已完整接收
+              const completeToolCalls = accumulatedToolCalls.filter(tc => tc.id && tc.name);
+              
+              if (completeToolCalls.length === 0) {
+                console.warn("[openai-adapter] No complete tool calls found");
+                break;
+              }
+              
+              yield {
+                type: "assistant",
+                message: {
+                  content: completeToolCalls.map(tc => {
+                    let parsedInput: unknown = {};
+                    try {
+                      parsedInput = JSON.parse(tc.arguments || "{}");
+                    } catch (error) {
+                      console.error(`[openai-adapter] Failed to parse tool arguments for ${tc.name}:`, error, "Arguments:", tc.arguments);
+                      parsedInput = {};
+                    }
+                    return {
+                      type: "tool_use",
+                      id: tc.id,
+                      name: tc.name,
+                      input: parsedInput
+                    };
+                  }),
+                  role: "assistant"
+                },
+                parent_tool_use_id: null,
+                uuid: crypto.randomUUID(),
+                session_id: sessionId
+              } as unknown as SDKMessage;
+
+              // 处理工具调用
+              const toolResults: OpenAIMessage[] = [];
+              for (const toolCall of completeToolCalls) {
+                if (onToolCall) {
+                  try {
+                    let toolInput: unknown = {};
+                    try {
+                      toolInput = JSON.parse(toolCall.arguments || "{}");
+                    } catch (error) {
+                      console.error(`[openai-adapter] Failed to parse tool arguments for ${toolCall.name}:`, error, "Arguments:", toolCall.arguments);
+                      toolInput = {};
+                    }
+                    const result = await onToolCall(toolCall.name, toolInput, toolCall.id);
+
+                    // 处理 PermissionResult
+                    let toolContent: string;
+                    if (typeof result === "object" && result !== null && "behavior" in result) {
+                      if (result.behavior === "allow" && "updatedInput" in result) {
+                        toolContent = JSON.stringify(result.updatedInput || toolInput);
+                      } else if (result.behavior === "deny" && "message" in result) {
+                        toolContent = JSON.stringify({error: result.message || "Permission denied"});
+                      } else {
+                        toolContent = JSON.stringify({error: "Permission denied"});
+                      }
+                    } else {
+                      toolContent = typeof result === "string" ? result : JSON.stringify(result);
+                    }
+
+                    toolResults.push({
+                      role: "tool",
+                      content: toolContent,
+                      tool_call_id: toolCall.id
+                    });
+                  } catch (error) {
+                    console.error(`[openai-adapter] Tool call failed for ${toolCall.name}:`, error);
+                    toolResults.push({
+                      role: "tool",
+                      content: JSON.stringify({error: String(error)}),
+                      tool_call_id: toolCall.id
+                    });
+                  }
+                }
+              }
+
+              // 更新消息历史，准备下一轮请求
+              currentMessageHistory.push({
+                role: "assistant",
+                content: "",
+                tool_calls: completeToolCalls.map(tc => ({
+                  id: tc.id,
+                  type: "function" as const,
+                  function: {
+                    name: tc.name,
+                    arguments: tc.arguments
+                  }
+                }))
+              });
+              currentMessageHistory.push(...toolResults);
+              accumulatedToolCalls = [];
+              accumulatedContent = "";
+
+              // 继续下一轮循环，发送包含工具结果的请求
+              break;
+            }
+          } catch (error) {
+            console.error("[openai-adapter] Failed to parse chunk:", error, "Data:", dataStr);
+          }
+        }
+      }
+
+      // 检查是否收到了任何数据
+      if (!hasReceivedData) {
+        console.warn("[openai-adapter] No data received from stream");
+      }
+
+      // 如果没有工具调用，且流已结束，发送最终结果并退出
+      if (!hasToolCalls) {
+        if (accumulatedContent) {
+          // 更新消息历史
+          currentMessageHistory.push({
+            role: "assistant",
+            content: accumulatedContent
+          });
+        }
+
+        // 发送最终结果
+        yield {
+          type: "result",
+          subtype: "success",
+          duration_ms: 0,
+          duration_api_ms: 0,
+          is_error: false,
+          num_turns: 1,
+          result: accumulatedContent,
+          total_cost_usd: 0,
+          usage: {input_tokens: 0, output_tokens: 0},
+          modelUsage: {},
+          permission_denials: [],
+          uuid: crypto.randomUUID(),
+          session_id: sessionId
+        } as unknown as SDKMessage;
+        return;
+      }
+    } catch (error) {
+       console.error("[openai-adapter] Error in openaiChatCompletion:", error);
+        if (error instanceof Error && error.name === "AbortError") {
+          yield {
+            type: "result",
+            subtype: "error_during_execution",
+            duration_ms: 0,
+            duration_api_ms: 0,
+            is_error: true,
+            num_turns: 0,
+            total_cost_usd: 0,
+            usage: {input_tokens: 0, output_tokens: 0},
+            modelUsage: {},
+            permission_denials: [],
+            errors: ["Request aborted"],
+            uuid: crypto.randomUUID(),
+            session_id: sessionId
+          } as unknown as SDKMessage;
+          return;
+        }
+
+        yield {
+          type: "result",
+          subtype: "error_during_execution",
+          duration_ms: 0,
+          duration_api_ms: 0,
+          is_error: true,
+          num_turns: 0,
+          total_cost_usd: 0,
+          usage: {input_tokens: 0, output_tokens: 0},
+          modelUsage: {},
+          permission_denials: [],
+          errors: [error instanceof Error ? error.message : String(error)],
+          uuid: crypto.randomUUID(),
+          session_id: sessionId
+        } as unknown as SDKMessage;
+        return;
+      }
+    }
+  }
+
+
+// 生成会话标题（使用 OpenAI 格式）
+export async function openaiGenerateTitle(
+      config: ApiConfig,
+      userIntent: string
+  ): Promise<string> {
+    const baseURL = config.baseURL.endsWith("/")
+        ? config.baseURL.slice(0, -1)
+        : config.baseURL;
+    const apiURL = baseURL.includes("/v1")
+        ? `${baseURL}/chat/completions`
+        : `${baseURL}/v1/chat/completions`;
+
+    const messages: OpenAIMessage[] = [
+      {
+        role: "user",
+        content: `Please analyze the following user input to generate a short but clear title to identify this conversation theme:\n${userIntent}\n\nDirectly output the title, do not include any other content.`
+      }
+    ];
+
+    try {
+      const response = await fetch(apiURL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${config.apiKey}`
+        },
+        body: JSON.stringify({
+          model: config.model,
+          messages,
+          stream: false
+        })
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`OpenAI API error: ${response.status} ${errorText}`);
+      }
+
+      const data = await response.json();
+      const content = data.choices[0]?.message?.content;
+      return content?.trim() || "New Session";
+    } catch (error) {
+      console.error("[openai-adapter] Failed to generate title:", error);
+      throw error;
+    }
+  }
+

--- a/src/electron/libs/runner.ts
+++ b/src/electron/libs/runner.ts
@@ -2,6 +2,15 @@ import { query, type SDKMessage, type PermissionResult } from "@anthropic-ai/cla
 import type { ServerEvent } from "../types.js";
 import type { Session } from "./session-store.js";
 import { claudeCodePath, enhancedEnv} from "./util.js";
+import { getCurrentApiConfig, buildEnvForConfig } from "./claude-settings.js";
+import { openaiChatCompletion } from "./openai-adapter.js";
+import { sessions as sessionStore } from "../ipc-handlers.js";
+import { readFileSync, writeFileSync, readdirSync } from "fs";
+import { exec } from "child_process";
+import { promisify } from "util";
+import { join, resolve } from "path";
+
+const execAsync = promisify(exec);
 
 
 export type RunnerOptions = {
@@ -17,6 +26,38 @@ export type RunnerHandle = {
 };
 
 const DEFAULT_CWD = process.cwd();
+
+// 获取消息历史用于 OpenAI 格式（从会话历史中提取）
+async function getMessageHistoryForOpenAI(sessionId: string): Promise<Array<{ role: "user" | "assistant" | "system" | "tool"; content: string; tool_call_id?: string }>> {
+  const history = sessionStore.getSessionHistory(sessionId);
+  if (!history) return [];
+
+  const messages: Array<{ role: "user" | "assistant" | "system" | "tool"; content: string; tool_call_id?: string }> = [];
+  
+  for (const msg of history.messages) {
+    if (msg.type === "user_prompt") {
+      messages.push({
+        role: "user",
+        content: msg.prompt
+      });
+    } else if (msg.type === "assistant" && "content" in msg) {
+      const content = msg.content as Array<{ type: string; text?: string }>;
+      const textContent = content
+        .filter(c => c.type === "text")
+        .map(c => c.text || "")
+        .join("\n");
+      
+      if (textContent) {
+        messages.push({
+          role: "assistant",
+          content: textContent
+        });
+      }
+    }
+  }
+  
+  return messages;
+}
 
 
 export async function runClaude(options: RunnerOptions): Promise<RunnerHandle> {
@@ -40,72 +81,250 @@ export async function runClaude(options: RunnerOptions): Promise<RunnerHandle> {
   // Start the query in the background
   (async () => {
     try {
-      const q = query({
-        prompt,
-        options: {
-          cwd: session.cwd ?? DEFAULT_CWD,
-          resume: resumeSessionId,
-          abortController,
-          env: enhancedEnv,
-          pathToClaudeCodeExecutable: claudeCodePath,
-          permissionMode: "bypassPermissions",
-          includePartialMessages: true,
-          allowDangerouslySkipPermissions: true,
-          canUseTool: async (toolName, input, { signal }) => {
+      // 获取当前配置
+      const config = getCurrentApiConfig();
+      const apiType = config?.apiType || "anthropic";
+
+      // 根据 API 类型选择不同的调用方式
+      if (apiType === "openai-compatible" && config) {
+        console.log("[runner] Using OpenAI-compatible adapter");
+        console.log("[runner] Config:", { 
+          baseURL: config.baseURL, 
+          model: config.model, 
+          apiType: config.apiType 
+        });
+        
+        // 使用 OpenAI 兼容适配器
+        // 新会话（没有 resumeSessionId）时不传递历史记录
+        const messageHistory = resumeSessionId 
+          ? await getMessageHistoryForOpenAI(session.id)
+          : [];
+        
+        console.log("[runner] Message history length:", messageHistory.length, "resumeSessionId:", resumeSessionId);
+
+        const q = openaiChatCompletion(
+          config,
+          prompt,
+          messageHistory,
+          async (toolName, input, toolCallId) => {
             // For AskUserQuestion, we need to wait for user response
             if (toolName === "AskUserQuestion") {
-              const toolUseId = crypto.randomUUID();
-
               // Send permission request to frontend
-              sendPermissionRequest(toolUseId, toolName, input);
+              sendPermissionRequest(toolCallId, toolName, input);
 
               // Create a promise that will be resolved when user responds
               return new Promise<PermissionResult>((resolve) => {
-                session.pendingPermissions.set(toolUseId, {
-                  toolUseId,
+                session.pendingPermissions.set(toolCallId, {
+                  toolUseId: toolCallId,
                   toolName,
                   input,
                   resolve: (result) => {
-                    session.pendingPermissions.delete(toolUseId);
+                    session.pendingPermissions.delete(toolCallId);
                     resolve(result as PermissionResult);
                   }
                 });
 
                 // Handle abort
-                signal.addEventListener("abort", () => {
-                  session.pendingPermissions.delete(toolUseId);
+                abortController.signal.addEventListener("abort", () => {
+                  session.pendingPermissions.delete(toolCallId);
                   resolve({ behavior: "deny", message: "Session aborted" });
                 });
               });
             }
 
-            // Auto-approve other tools
-            return { behavior: "allow", updatedInput: input };
+            // 执行其他工具
+            const cwd = session.cwd ?? DEFAULT_CWD;
+            let toolResult: unknown;
+
+            try {
+              // 验证输入参数
+              if (!input || typeof input !== "object" || Array.isArray(input)) {
+                throw new Error(`Invalid input for tool ${toolName}: expected object, got ${typeof input}`);
+              }
+
+              switch (toolName) {
+                case "ReadFile": {
+                  const path = (input as { path?: string }).path;
+                  if (!path || typeof path !== "string") {
+                    throw new Error("ReadFile requires a 'path' parameter of type string");
+                  }
+                  const fullPath = resolve(cwd, path);
+                  const content = readFileSync(fullPath, "utf8");
+                  toolResult = { content };
+                  break;
+                }
+                case "WriteFile": {
+                  const { path, content } = input as { path?: string; content?: string };
+                  if (!path || typeof path !== "string") {
+                    throw new Error("WriteFile requires a 'path' parameter of type string");
+                  }
+                  if (content === undefined) {
+                    throw new Error("WriteFile requires a 'content' parameter");
+                  }
+                  const fullPath = resolve(cwd, path);
+                  writeFileSync(fullPath, String(content), "utf8");
+                  toolResult = { success: true };
+                  break;
+                }
+                case "ListDirectory": {
+                  // 如果没有提供 path，直接使用会话的工作目录（参考 Anthropic SDK 的行为）
+                  const path = (input as { path?: string }).path;
+                  // 如果 path 为空或未提供，直接使用 cwd；否则相对于 cwd 解析路径
+                  const fullPath = path && typeof path === "string" && path.trim() !== "" 
+                    ? resolve(cwd, path)
+                    : cwd;
+                  const entries = readdirSync(fullPath, { withFileTypes: true });
+                  toolResult = {
+                    entries: entries.map(entry => ({
+                      name: entry.name,
+                      type: entry.isDirectory() ? "directory" : "file"
+                    }))
+                  };
+                  break;
+                }
+                case "RunCommand": {
+                  const command = (input as { command?: string }).command;
+                  if (!command || typeof command !== "string") {
+                    throw new Error("RunCommand requires a 'command' parameter of type string");
+                  }
+                  const { stdout, stderr } = await execAsync(command, { cwd });
+                  toolResult = {
+                    stdout: stdout || "",
+                    stderr: stderr || "",
+                    exitCode: 0
+                  };
+                  break;
+                }
+                default:
+                  toolResult = { error: `Unknown tool: ${toolName}` };
+              }
+
+              // 返回工具执行结果
+              // 确保 updatedInput 是 Record<string, unknown> 类型
+              const updatedInput: Record<string, unknown> = 
+                typeof toolResult === "object" && toolResult !== null && !Array.isArray(toolResult)
+                  ? toolResult as Record<string, unknown>
+                  : { result: toolResult };
+              
+              return {
+                behavior: "allow",
+                updatedInput
+              };
+            } catch (error) {
+              console.error(`[runner] Tool execution failed for ${toolName}:`, error);
+              return {
+                behavior: "allow",
+                updatedInput: {
+                  error: error instanceof Error ? error.message : String(error)
+                }
+              };
+            }
+          },
+          abortController.signal,
+          {
+            cwd: session.cwd,
+            permissionMode: "bypassPermissions"
+          }
+        );
+
+        // 处理 OpenAI 消息流
+        for await (const message of q) {
+          // Extract session_id from system init message
+          if (message.type === "system" && "subtype" in message && message.subtype === "init") {
+            const sdkSessionId = (message as any).session_id;
+            if (sdkSessionId) {
+              session.claudeSessionId = sdkSessionId;
+              onSessionUpdate?.({ claudeSessionId: sdkSessionId });
+            }
+          }
+
+          // Send message to frontend
+          sendMessage(message);
+
+          // Check for result to update session status
+          if (message.type === "result") {
+            const status = message.subtype === "success" ? "completed" : "error";
+            onEvent({
+              type: "session.status",
+              payload: { sessionId: session.id, status, title: session.title }
+            });
           }
         }
-      });
+      } else {
+        // 使用 Anthropic SDK
+        const env = buildEnvForConfig(config);
+        const mergedEnv = {
+          ...enhancedEnv,
+          ...env
+        };
 
-      // Capture session_id from init message
-      for await (const message of q) {
-        // Extract session_id from system init message
-        if (message.type === "system" && "subtype" in message && message.subtype === "init") {
-          const sdkSessionId = message.session_id;
-          if (sdkSessionId) {
-            session.claudeSessionId = sdkSessionId;
-            onSessionUpdate?.({ claudeSessionId: sdkSessionId });
+        const q = query({
+          prompt,
+          options: {
+            cwd: session.cwd ?? DEFAULT_CWD,
+            resume: resumeSessionId,
+            abortController,
+            env: mergedEnv,
+            pathToClaudeCodeExecutable: claudeCodePath,
+            permissionMode: "bypassPermissions",
+            includePartialMessages: true,
+            allowDangerouslySkipPermissions: true,
+            canUseTool: async (toolName, input, { signal }) => {
+              // For AskUserQuestion, we need to wait for user response
+              if (toolName === "AskUserQuestion") {
+                const toolUseId = crypto.randomUUID();
+
+                // Send permission request to frontend
+                sendPermissionRequest(toolUseId, toolName, input);
+
+                // Create a promise that will be resolved when user responds
+                return new Promise<PermissionResult>((resolve) => {
+                  session.pendingPermissions.set(toolUseId, {
+                    toolUseId,
+                    toolName,
+                    input,
+                    resolve: (result) => {
+                      session.pendingPermissions.delete(toolUseId);
+                      resolve(result as PermissionResult);
+                    }
+                  });
+
+                  // Handle abort
+                  signal.addEventListener("abort", () => {
+                    session.pendingPermissions.delete(toolUseId);
+                    resolve({ behavior: "deny", message: "Session aborted" });
+                  });
+                });
+              }
+
+              // Auto-approve other tools
+              return { behavior: "allow", updatedInput: input };
+            }
           }
-        }
+        });
 
-        // Send message to frontend
-        sendMessage(message);
+        // Capture session_id from init message
+        for await (const message of q) {
+          // Extract session_id from system init message
+          if (message.type === "system" && "subtype" in message && message.subtype === "init") {
+            const sdkSessionId = message.session_id;
+            if (sdkSessionId) {
+              session.claudeSessionId = sdkSessionId;
+              onSessionUpdate?.({ claudeSessionId: sdkSessionId });
+            }
+          }
 
-        // Check for result to update session status
-        if (message.type === "result") {
-          const status = message.subtype === "success" ? "completed" : "error";
-          onEvent({
-            type: "session.status",
-            payload: { sessionId: session.id, status, title: session.title }
-          });
+          // Send message to frontend
+          sendMessage(message);
+
+          // Check for result to update session status
+          if (message.type === "result") {
+            const status = message.subtype === "success" ? "completed" : "error";
+            onEvent({
+              type: "session.status",
+              payload: { sessionId: session.id, status, title: session.title }
+            });
+          }
         }
       }
 

--- a/src/electron/libs/util.ts
+++ b/src/electron/libs/util.ts
@@ -1,6 +1,7 @@
-import { claudeCodeEnv } from "./claude-settings.js";
+import { getCurrentApiConfig, buildEnvForConfig } from "./claude-settings.js";
 import { unstable_v2_prompt } from "@anthropic-ai/claude-agent-sdk";
 import type { SDKResultMessage } from "@anthropic-ai/claude-agent-sdk";
+import { openaiGenerateTitle } from "./openai-adapter.js";
 import { app } from "electron";
 import { join } from "path";
 import { homedir } from "os";
@@ -44,22 +45,64 @@ export function getEnhancedEnv(): Record<string, string | undefined> {
 export const claudeCodePath = getClaudeCodePath();
 export const enhancedEnv = getEnhancedEnv();
 
+// 从用户输入中提取标题的辅助函数
+function extractTitleFromInput(userIntent: string): string {
+  // 移除换行和多余空格
+  const cleaned = userIntent.trim().replace(/\s+/g, ' ');
+  // 取前 50 个字符
+  const title = cleaned.slice(0, 50);
+  // 如果被截断，添加省略号
+  return cleaned.length > 50 ? `${title}...` : title;
+}
+
 export const generateSessionTitle = async (userIntent: string | null) => {
   if (!userIntent) return "New Session";
 
-  const result: SDKResultMessage = await unstable_v2_prompt(
-    `please analynis the following user input to generate a short but clearly title to identify this conversation theme:
-    ${userIntent}
-    directly output the title, do not include any other content`, {
-    model: claudeCodeEnv.ANTHROPIC_MODEL,
-    env: enhancedEnv,
-    pathToClaudeCodeExecutable: claudeCodePath,
-  });
+  try {
+    // 获取当前配置
+    const config = getCurrentApiConfig();
+    const apiType = config?.apiType || "anthropic";
 
-  if (result.subtype === "success") {
-    return result.result;
+    // 根据 API 类型选择不同的调用方式
+    if (apiType === "openai-compatible" && config) {
+      try {
+        return await openaiGenerateTitle(config, userIntent);
+      } catch (error) {
+        console.error("[generateSessionTitle] OpenAI API failed:", error);
+        return extractTitleFromInput(userIntent);
+      }
+    } else {
+      // 使用 Anthropic SDK
+      const env = buildEnvForConfig(config);
+      const model = config?.model || process.env.ANTHROPIC_MODEL || "claude-3-5-sonnet-20241022";
+      
+      // 合并环境变量
+      const mergedEnv = {
+        ...enhancedEnv,
+        ...env
+      };
+
+      const result: SDKResultMessage = await unstable_v2_prompt(
+        `please analynis the following user input to generate a short but clearly title to identify this conversation theme:
+        ${userIntent}
+        directly output the title, do not include any other content`, {
+        model,
+        env: mergedEnv,
+        pathToClaudeCodeExecutable: claudeCodePath,
+      });
+
+      if (result.subtype === "success") {
+        return result.result;
+      }
+
+      // API 调用成功但返回失败状态，使用降级策略
+      console.warn("[generateSessionTitle] API returned non-success result:", result);
+      return extractTitleFromInput(userIntent);
+    }
+  } catch (error) {
+    // API 调用失败（可能是兼容性问题），使用降级策略
+    console.error("[generateSessionTitle] Failed to generate title via API:", error);
+    console.info("[generateSessionTitle] Falling back to extracted title from user input");
+    return extractTitleFromInput(userIntent);
   }
-
-
-  return "New Session";
 };

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -5,6 +5,7 @@ import { getStaticData, pollResources } from "./test.js";
 import { handleClientEvent, sessions } from "./ipc-handlers.js";
 import { generateSessionTitle } from "./libs/util.js";
 import type { ClientEvent } from "./types.js";
+import { loadApiConfig, saveApiConfig, type ApiConfig } from "./libs/config-store.js";
 import "./libs/claude-settings.js";
 
 app.on("ready", () => {
@@ -58,5 +59,20 @@ app.on("ready", () => {
         }
         
         return result.filePaths[0];
+    });
+
+    // Handle API config
+    ipcMainHandle("get-api-config", () => {
+        return loadApiConfig();
+    });
+
+    ipcMainHandle("save-api-config", (_: any, config: ApiConfig) => {
+        try {
+            saveApiConfig(config);
+            return { success: true };
+        } catch (error) {
+            console.error("[main] Failed to save API config:", error);
+            return { success: false, error: String(error) };
+        }
     });
 })

--- a/src/electron/preload.cts
+++ b/src/electron/preload.cts
@@ -28,7 +28,11 @@ electron.contextBridge.exposeInMainWorld("electron", {
     getRecentCwds: (limit?: number) => 
         ipcInvoke("get-recent-cwds", limit),
     selectDirectory: () => 
-        ipcInvoke("select-directory")
+        ipcInvoke("select-directory"),
+    getApiConfig: () => 
+        ipcInvoke("get-api-config"),
+    saveApiConfig: (config: { apiKey: string; baseURL: string; model: string }) => 
+        ipcInvoke("save-api-config", config)
 } satisfies Window['electron'])
 
 function ipcInvoke<Key extends keyof EventPayloadMapping>(key: Key, ...args: any[]): Promise<EventPayloadMapping[Key]> {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from "./store/useAppStore";
 import type { ServerEvent } from "./types";
 import { Sidebar } from "./components/Sidebar";
 import { StartSessionModal } from "./components/StartSessionModal";
+import { SettingsModal } from "./components/SettingsModal";
 import { PromptInput, usePromptActions } from "./components/PromptInput";
 import { MessageCard } from "./components/EventCard";
 import MDContent from "./render/markdown";
@@ -19,6 +20,8 @@ function App() {
   const activeSessionId = useAppStore((s) => s.activeSessionId);
   const showStartModal = useAppStore((s) => s.showStartModal);
   const setShowStartModal = useAppStore((s) => s.setShowStartModal);
+  const showSettingsModal = useAppStore((s) => s.showSettingsModal);
+  const setShowSettingsModal = useAppStore((s) => s.setShowSettingsModal);
   const globalError = useAppStore((s) => s.globalError);
   const setGlobalError = useAppStore((s) => s.setGlobalError);
   const historyRequested = useAppStore((s) => s.historyRequested);
@@ -120,6 +123,7 @@ function App() {
         connected={connected}
         onNewSession={handleNewSession}
         onDeleteSession={handleDeleteSession}
+        onOpenSettings={() => setShowSettingsModal(true)}
       />
 
       <main className="flex flex-1 flex-col ml-[280px] bg-surface-cream">
@@ -190,6 +194,12 @@ function App() {
           onPromptChange={setPrompt}
           onStart={handleStartFromModal}
           onClose={() => setShowStartModal(false)}
+        />
+      )}
+
+      {showSettingsModal && (
+        <SettingsModal
+          onClose={() => setShowSettingsModal(false)}
         />
       )}
 

--- a/src/ui/components/SettingsModal.tsx
+++ b/src/ui/components/SettingsModal.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useState } from "react";
+
+interface SettingsModalProps {
+  onClose: () => void;
+}
+
+export function SettingsModal({ onClose }: SettingsModalProps) {
+  const [apiKey, setApiKey] = useState("");
+  const [baseURL, setBaseURL] = useState("");
+  const [model, setModel] = useState("");
+  const [apiType, setApiType] = useState<"anthropic" | "openai-compatible">("anthropic");
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  useEffect(() => {
+    // 加载当前配置
+    setLoading(true);
+    window.electron.getApiConfig()
+      .then((config) => {
+        if (config) {
+          setApiKey(config.apiKey);
+          setBaseURL(config.baseURL);
+          setModel(config.model);
+          setApiType(config.apiType || "anthropic");
+        }
+      })
+      .catch((err) => {
+        console.error("Failed to load API config:", err);
+        setError("Failed to load configuration");
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, []);
+
+  const handleSave = async () => {
+    // 验证输入
+    if (!apiKey.trim()) {
+      setError("API Key is required");
+      return;
+    }
+    if (!baseURL.trim()) {
+      setError("Base URL is required");
+      return;
+    }
+    if (!model.trim()) {
+      setError("Model is required");
+      return;
+    }
+
+    // 验证 URL 格式
+    try {
+      new URL(baseURL);
+    } catch {
+      setError("Invalid Base URL format");
+      return;
+    }
+
+    setError(null);
+    setSaving(true);
+
+    try {
+      const result = await window.electron.saveApiConfig({
+        apiKey: apiKey.trim(),
+        baseURL: baseURL.trim(),
+        model: model.trim(),
+        apiType: apiType
+      });
+
+      if (result.success) {
+        setSuccess(true);
+        setTimeout(() => {
+          setSuccess(false);
+          onClose();
+        }, 1000);
+      } else {
+        setError(result.error || "Failed to save configuration");
+      }
+    } catch (err) {
+      console.error("Failed to save API config:", err);
+      setError("Failed to save configuration");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-ink-900/20 px-4 py-8 backdrop-blur-sm">
+      <div className="w-full max-w-lg rounded-2xl border border-ink-900/5 bg-surface p-6 shadow-elevated">
+        <div className="flex items-center justify-between">
+          <div className="text-base font-semibold text-ink-800">API Configuration</div>
+          <button 
+            className="rounded-full p-1.5 text-muted hover:bg-surface-tertiary hover:text-ink-700 transition-colors" 
+            onClick={onClose} 
+            aria-label="Close"
+          >
+            <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <p className="mt-2 text-sm text-muted">Configure API key, base URL, model, and API format for the AI agent.</p>
+        
+        {loading ? (
+          <div className="mt-5 flex items-center justify-center py-8">
+            <svg aria-hidden="true" className="w-6 h-6 animate-spin text-accent" viewBox="0 0 100 101" fill="none">
+              <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor" opacity="0.3" />
+              <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentColor" />
+            </svg>
+          </div>
+        ) : (
+          <div className="mt-5 grid gap-4">
+            <label className="grid gap-1.5">
+              <span className="text-xs font-medium text-muted">API Format</span>
+              <select
+                className="rounded-xl border border-ink-900/10 bg-surface-secondary px-4 py-2.5 text-sm text-ink-800 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/20 transition-colors"
+                value={apiType}
+                onChange={(e) => setApiType(e.target.value as "anthropic" | "openai-compatible")}
+              >
+                <option value="anthropic">Anthropic API</option>
+                <option value="openai-compatible">OpenAI-Compatible API</option>
+              </select>
+              <p className="text-xs text-muted-light mt-1">
+                {apiType === "anthropic" 
+                  ? "Use Anthropic's native API format (Claude models)"
+                  : "Use OpenAI-compatible API format (works with any compatible model)"}
+              </p>
+            </label>
+            <label className="grid gap-1.5">
+              <span className="text-xs font-medium text-muted">API Key</span>
+              <input
+                type="password"
+                className="rounded-xl border border-ink-900/10 bg-surface-secondary px-4 py-2.5 text-sm text-ink-800 placeholder:text-muted-light focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/20 transition-colors"
+                placeholder="sk-..."
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                required
+              />
+            </label>
+            <label className="grid gap-1.5">
+              <span className="text-xs font-medium text-muted">Base URL</span>
+              <input
+                type="url"
+                className="rounded-xl border border-ink-900/10 bg-surface-secondary px-4 py-2.5 text-sm text-ink-800 placeholder:text-muted-light focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/20 transition-colors"
+                placeholder={apiType === "anthropic" ? "https://api.anthropic.com" : "https://api.openai.com/v1"}
+                value={baseURL}
+                onChange={(e) => setBaseURL(e.target.value)}
+                required
+              />
+              {apiType === "openai-compatible" && (
+                <p className="text-xs text-muted-light mt-1">
+                  Example: https://api.openai.com/v1 or https://your-api-gateway.com/v1
+                </p>
+              )}
+            </label>
+            <label className="grid gap-1.5">
+              <span className="text-xs font-medium text-muted">Model</span>
+              <input
+                type="text"
+                className="rounded-xl border border-ink-900/10 bg-surface-secondary px-4 py-2.5 text-sm text-ink-800 placeholder:text-muted-light focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/20 transition-colors"
+                placeholder={apiType === "anthropic" ? "claude-3-5-sonnet-20241022" : "gpt-4"}
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                required
+              />
+            </label>
+            
+            {error && (
+              <div className="rounded-xl border border-error/20 bg-error-light px-4 py-2.5 text-sm text-error">
+                {error}
+              </div>
+            )}
+            
+            {success && (
+              <div className="rounded-xl border border-success/20 bg-success-light px-4 py-2.5 text-sm text-success">
+                Configuration saved successfully!
+              </div>
+            )}
+
+            <div className="flex gap-3">
+              <button
+                className="flex-1 rounded-xl border border-ink-900/10 bg-surface px-4 py-2.5 text-sm font-medium text-ink-700 hover:bg-surface-tertiary transition-colors"
+                onClick={onClose}
+                disabled={saving}
+              >
+                Cancel
+              </button>
+              <button
+                className="flex-1 rounded-xl bg-accent px-4 py-2.5 text-sm font-medium text-white shadow-soft hover:bg-accent-hover transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                onClick={handleSave}
+                disabled={saving || !apiKey.trim() || !baseURL.trim() || !model.trim()}
+              >
+                {saving ? (
+                  <svg aria-hidden="true" className="mx-auto w-5 h-5 animate-spin" viewBox="0 0 100 101" fill="none">
+                    <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor" opacity="0.3" />
+                    <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="white" />
+                  </svg>
+                ) : "Save"}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -7,11 +7,13 @@ interface SidebarProps {
   connected: boolean;
   onNewSession: () => void;
   onDeleteSession: (sessionId: string) => void;
+  onOpenSettings: () => void;
 }
 
 export function Sidebar({
   onNewSession,
-  onDeleteSession
+  onDeleteSession,
+  onOpenSettings
 }: SidebarProps) {
   const sessions = useAppStore((state) => state.sessions);
   const activeSessionId = useAppStore((state) => state.activeSessionId);
@@ -78,6 +80,16 @@ export function Sidebar({
         onClick={onNewSession}
       >
         + New Task
+      </button>
+      <button
+        className="w-full rounded-xl border border-ink-900/10 bg-surface px-4 py-2.5 text-sm font-medium text-ink-700 hover:bg-surface-tertiary hover:border-ink-900/20 transition-colors flex items-center justify-center gap-2"
+        onClick={onOpenSettings}
+      >
+        <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2">
+          <circle cx="12" cy="12" r="3" />
+          <path d="M12 1v6m0 6v6M5.64 5.64l4.24 4.24m4.24 4.24l4.24 4.24M1 12h6m6 0h6M5.64 18.36l4.24-4.24m4.24-4.24l4.24-4.24" />
+        </svg>
+        Settings
       </button>
       <div className="flex flex-col gap-2 overflow-y-auto">
         {sessionList.length === 0 && (

--- a/src/ui/store/useAppStore.ts
+++ b/src/ui/store/useAppStore.ts
@@ -29,6 +29,7 @@ interface AppState {
   globalError: string | null;
   sessionsLoaded: boolean;
   showStartModal: boolean;
+  showSettingsModal: boolean;
   historyRequested: Set<string>;
 
   setPrompt: (prompt: string) => void;
@@ -36,6 +37,7 @@ interface AppState {
   setPendingStart: (pending: boolean) => void;
   setGlobalError: (error: string | null) => void;
   setShowStartModal: (show: boolean) => void;
+  setShowSettingsModal: (show: boolean) => void;
   setActiveSessionId: (id: string | null) => void;
   markHistoryRequested: (sessionId: string) => void;
   resolvePermissionRequest: (sessionId: string, toolUseId: string) => void;
@@ -55,6 +57,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   globalError: null,
   sessionsLoaded: false,
   showStartModal: false,
+  showSettingsModal: false,
   historyRequested: new Set(),
 
   setPrompt: (prompt) => set({ prompt }),
@@ -62,6 +65,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   setPendingStart: (pendingStart) => set({ pendingStart }),
   setGlobalError: (globalError) => set({ globalError }),
   setShowStartModal: (showStartModal) => set({ showStartModal }),
+  setShowSettingsModal: (showSettingsModal) => set({ showSettingsModal }),
   setActiveSessionId: (id) => set({ activeSessionId: id }),
 
   markHistoryRequested: (sessionId) => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -18,6 +18,8 @@ type EventPayloadMapping = {
     "generate-session-title": string;
     "get-recent-cwds": string[];
     "select-directory": string | null;
+    "get-api-config": { apiKey: string; baseURL: string; model: string; apiType?: "anthropic" | "openai-compatible" } | null;
+    "save-api-config": { success: boolean; error?: string };
 }
 
 interface Window {
@@ -30,5 +32,7 @@ interface Window {
         generateSessionTitle: (userInput: string | null) => Promise<string>;
         getRecentCwds: (limit?: number) => Promise<string[]>;
         selectDirectory: () => Promise<string | null>;
+        getApiConfig: () => Promise<{ apiKey: string; baseURL: string; model: string; apiType?: "anthropic" | "openai-compatible" } | null>;
+        saveApiConfig: (config: { apiKey: string; baseURL: string; model: string; apiType?: "anthropic" | "openai-compatible" }) => Promise<{ success: boolean; error?: string }>;
     }
 }


### PR DESCRIPTION
- 新增 config-store 与 openai-adapter，支持 Anthropics 与 OpenAI 兼容接口切换
- 新增设置弹窗，前端可配置 apiKey/baseURL/model/apiType
- 通过 IPC 在主进程读写 API 配置并影响会话与标题生成
- Runner 增加 OpenAI 消息/工具调用适配与历史转换逻辑

----
效果如下：
### 设置入口
<img width="2400" height="1600" alt="screenshot-20260114-180425" src="https://github.com/user-attachments/assets/d4bf7589-d0d3-42be-83dd-24e0f48fe507" />

### 设置页面
>支持 Anthropics 和 OpenAI 兼容接口
<img width="2400" height="1600" alt="screenshot-20260114-174741" src="https://github.com/user-attachments/assets/1fac871d-c367-4343-ad3a-a21562168edf" />
